### PR TITLE
fix(seo,i18n): logo 多语言切换 + SEO 基础设施 + hreflang/description 修复

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,90 @@ bash scripts/install-hooks.sh
 
 ---
 
+## 多语言（i18n）并行修改约束 ⭐
+
+**本博客是 jekyll-polyglot 三语站**（en / zh / ja）。任何改动若涉及"内容 / 文案 / 路径 / 元数据"，**必须三语同步**，否则会出现：
+- 默认语言（en）显示中文 description → 谷歌相关性降分
+- 某个语言缺导航项 → 用户体验割裂
+- 某语言版本 excerpt / 版本号过时 → 信息不一致
+
+### 内容文件清单（每组必须三语齐全）
+
+| 组别 | 文件 |
+|---|---|
+| 首页 | `index.md` / `index.zh.md` / `index.ja.md` |
+| About | `about.md` / `about.zh.md` / `about.ja.md` |
+| Projects | `projects.md` / `projects.zh.md` / `projects.ja.md` |
+| aitm 产品页 | `aitm.md` / `aitm.zh.md` / `aitm.ja.md` |
+| PDLC 产品页 | `pdlc.md` / `pdlc.zh.md` / `pdlc.ja.md` |
+| arcade 产品页 | `arcade.md` / `arcade.zh.md` / `arcade.ja.md` |
+| 博客文章 | `_posts/YYYY-MM-DD-slug.md` (en) / `.zh.md` / `.ja.md` |
+
+> ⚠️ `_posts/*.md` 默认语言（en）**无后缀**，其他语言用 `.zh.md` / `.ja.md`。早期违规（无后缀但 lang: zh）已在 PR #14 规整。**新建文章必须遵守该命名**。
+
+### Frontmatter 必填字段（三语都要）
+
+| 字段 | 三语都要？ | 例 |
+|---|---|---|
+| `lang` | ✅ 必填，单字符代码 `en` / `zh` / `ja` | `lang: zh` |
+| `title` | ✅ 各语言写各语言的标题 | EN: "PDLC: turn..." / ZH: "PDLC：把..." |
+| `description` | ✅ 各语言写各语言版本（不许跨语言重用！） | 中文文件不写英文 description |
+| `excerpt`（_posts） | ✅ 各语言对等翻译 | — |
+| `permalink` | ✅ 三语共用同一个（polyglot 自动加前缀） | `/aitm/` 在三个文件里都写 |
+
+### 共用资源清单（**不**分语言，三语共用一份）
+
+| 路径 | 说明 |
+|---|---|
+| `assets/`（图片 / 下载文件 / 静态 JSON） | 已在 `_config.yml` `exclude_from_localization` |
+| `arcade/`（工具 SPA dist） | 同上 |
+| `_data/i18n.yml` | UI 框架文案库（nav / footer / search / post / tags / not_found / site_title / site_description）按语言键分组 |
+
+**新增需要"全语言文案"的字符串时**，加进 `_data/i18n.yml` 而不是写死在 layout 里。
+
+### 跨语言修改检查清单（每次提交三语相关改动时跑一遍）
+
+- [ ] 三语文件都已修改？（用 `git status` 验证有 3 个 .md 变更）
+- [ ] 三语 `description` 都用对应语言写了？没有出现"英文文件含中文描述"？
+- [ ] 如果新建一组三语文件，`_data/i18n.yml` 里有没有需要补的字符串？
+- [ ] _posts 文件名是否符合规范（默认 lang 无后缀，其他 lang 加 `.zh.md` / `.ja.md`）？
+- [ ] hreflang 链接是否能从一种语言切到另外两种？（看 `_layouts/default.html` 的 hreflang 生成逻辑，对博客文章会自动加 `.lang.html` 后缀）
+
+---
+
+## SEO 红线 ⭐
+
+### 必守约束
+
+1. **`sitemap.xml`**：由 `jekyll-sitemap` 插件自动生成；**不要手动改**。已知问题：当前 sitemap 只列默认 lang URL，缺多语言副本——靠 hreflang 链让 Google 自己发现，目前可接受。完整覆盖待后续手写 sitemap.xml.liquid。
+2. **`robots.txt`**：手维护文件（在仓库根）。当前禁止抓 `/arcade/play/`（SPA 空壳）。新加任何"低质量页面 / 工具页"也要在这里 Disallow。
+3. **arcade 工具 SPA**：必须保持 `<meta name="robots" content="noindex,follow">`（在 arcade_emulator 源码 `index.html`）。每次重 build + sync 不要丢这条。
+4. **canonical**：当前由 `jekyll-seo-tag` 自动生成。**已知问题**：非默认 lang 页面的 canonical 会错误指向 `/`（polyglot + seo-tag 兼容性）。临时容忍，因为 hreflang 提供了正确的语言关联。**未来修复**：在所有 `.zh.md` / `.ja.md` 加 frontmatter `canonical_url:` 字段显式声明。
+5. **hreflang**：在 `_layouts/default.html` 自动生成，能正确处理 `.lang.html` 后缀（PR #16）。**新增页面 / 新文章不需要手动设 hreflang**，layout 自动加。
+6. **三语 description 严格分语言写**（见上节多语言约束）。
+7. **每个页面只有 1 个 `<h1>`**。多 `<h1>` 会拖累 SEO 评分。
+8. **CSP 不可以拦截 GA / sitemap 爬虫**（当前白名单已含 googletagmanager + google-analytics）。改 CSP 时确认这一点。
+
+### 新增页面时的 SEO checklist
+
+- [ ] `title` 三语都写了？
+- [ ] `description` 三语都写了？
+- [ ] 是否会被 `jekyll-sitemap` 列入？（permalink 在 `_config.yml` `exclude_from_localization` 内的资源不会被列入）
+- [ ] 内容是否会拖低站点平均质量？（SPA 空壳、占位页等应加 `noindex`）
+- [ ] hreflang 在 layout 中生成正确吗？（curl `_site/<path>` 看 `<link rel="alternate" hreflang=...>`）
+
+### 已知遗留 SEO 项（按优先级）
+
+| 项 | 优先级 | 说明 |
+|---|---|---|
+| polyglot + jekyll-seo-tag canonical 错误 | P1 | 非默认 lang 页 canonical 指 `/`。临时容忍 |
+| sitemap 缺多语言副本 | P2 | 靠 hreflang 链发现，但官方 sitemap 应完整 |
+| og:image 缺失 | P2 | 社交分享无缩略图 |
+| 自定义 404 页 | P3 | 当前 GitHub Pages 默认 |
+| og:locale 用 `en` 而非 `en_US` | P3 | 小问题 |
+
+---
+
 ## aitm 安装包升级流程（重要）
 
 aitm 桌面端会拉 `https://kanfu-panda.github.io/assets/aitm/latest.json` 做 update_check。

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,6 @@ gem "webrick"
 
 # 多语言（中 / 英 / 日）
 gem "jekyll-polyglot"
+
+# SEO：生成 sitemap.xml；jekyll-seo-tag / jekyll-feed 已在 _config.yml plugins 中
+gem "jekyll-sitemap"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,8 @@ GEM
       sass-embedded (~> 1.75)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.12.2)
@@ -100,6 +102,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll
   jekyll-polyglot
+  jekyll-sitemap
   minima
   webrick
 

--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,7 @@ plugins:
   - jekyll-feed
   - jekyll-seo-tag
   - jekyll-polyglot
+  - jekyll-sitemap
 
 # 导航菜单
 header_pages:

--- a/_data/i18n.yml
+++ b/_data/i18n.yml
@@ -3,6 +3,7 @@
 # 新增语言时同步补齐 3 个语言键。
 
 en:
+  site_title: Kanfu Panda's Blog
   site_description: A developer who loves technology — notes, tools, and the occasional rabbit hole.
   nav:
     about: About
@@ -33,6 +34,7 @@ en:
     home: Back to home
 
 zh:
+  site_title: 功夫熊猫的博客
   site_description: 一个热爱技术的开发者的个人博客。
   nav:
     about: 关于
@@ -63,6 +65,7 @@ zh:
     home: 回到首页
 
 ja:
+  site_title: カンフーパンダのブログ
   site_description: テクノロジー好き開発者の個人ブログ。
   nav:
     about: プロフィール

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 {%- assign lang = page.lang | default: site.active_lang | default: site.default_lang -%}
 {%- assign t = site.data.i18n[lang] -%}
+{%- assign localized_site_title = t.site_title | default: site.title -%}
+{%- assign localized_site_description = t.site_description | default: site.description -%}
 {%- assign html_lang_attr = lang | replace: "zh", "zh-CN" | replace: "ja", "ja-JP" | replace: "en", "en-US" -%}
 <html lang="{{ html_lang_attr }}">
 <head>
@@ -10,7 +12,7 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; font-src 'self' data: https://cdnjs.cloudflare.com; img-src 'self' data: https://www.google-analytics.com https://*.githubusercontent.com https://*.gravatar.com; connect-src 'self' https://api.github.com https://www.google-analytics.com https://*.analytics.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://github.com">
     <meta name="referrer" content="strict-origin-when-cross-origin">
 
-    <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
+    <title>{% if page.title %}{{ page.title }} - {% endif %}{{ localized_site_title }}</title>
 
     {% if site.gitalk.enable and site.gitalk.clientID != empty and site.gitalk.clientSecret != empty and page.layout == 'post' and jekyll.environment == 'production' %}
     <!-- Gitalk (锁版本 + SRI；升级时需重新生成 integrity，方法见 SECURITY.md) -->
@@ -33,29 +35,43 @@
             crossorigin="anonymous"></script>
     {% seo %}
 
-    {%- comment -%} canonical_path：去掉 /<lang>/ 前缀后的"裸"路径，供 hreflang 与语言切换器使用 {%- endcomment -%}
-    {%- assign canonical_path = page.url -%}
+    {%- comment -%}
+      naked_path：去掉 /<lang>/ 前缀 与 .<lang>.html 后缀后的"裸"路径。
+      用于生成各语言版本的 hreflang URL：
+        - default_lang：naked_path 本身
+        - 其他 lang：/<lang> + naked_path 改后缀为 .<lang>.html（若为 .html 结尾）
+      博客文章 URL 形如 /blog/.../slug.zh.html、/zh/blog/.../slug.zh.html，
+      产品页形如 /aitm/、/zh/aitm/。两种结构都正确处理。
+    {%- endcomment -%}
+    {%- assign naked_path = page.url -%}
     {%- if lang != site.default_lang -%}
       {%- assign lang_prefix = "/" | append: lang -%}
       {%- assign lang_prefix_slash = lang_prefix | append: "/" -%}
-      {%- if canonical_path == lang_prefix_slash -%}
-        {%- assign canonical_path = "/" -%}
-      {%- elsif canonical_path == lang_prefix -%}
-        {%- assign canonical_path = "/" -%}
+      {%- if naked_path == lang_prefix_slash or naked_path == lang_prefix -%}
+        {%- assign naked_path = "/" -%}
       {%- else -%}
-        {%- assign canonical_path = canonical_path | remove_first: lang_prefix -%}
+        {%- assign naked_path = naked_path | remove_first: lang_prefix -%}
+      {%- endif -%}
+      {%- assign lang_suffix = "." | append: lang | append: ".html" -%}
+      {%- if naked_path contains lang_suffix -%}
+        {%- assign naked_path = naked_path | replace: lang_suffix, ".html" -%}
       {%- endif -%}
     {%- endif -%}
     <!-- hreflang：全部用 static_href 包裹，让 polyglot 的 URL relativize 跳过 -->
     {%- for l in site.languages -%}
       {%- if l == site.default_lang -%}
-        {%- assign alt_path = canonical_path -%}
+        {%- assign alt_path = naked_path -%}
       {%- else -%}
-        {%- assign alt_path = "/" | append: l | append: canonical_path -%}
+        {%- assign target_suffix = "." | append: l | append: ".html" -%}
+        {%- if naked_path contains ".html" -%}
+          {%- assign alt_path = "/" | append: l | append: naked_path | replace_first: ".html", target_suffix -%}
+        {%- else -%}
+          {%- assign alt_path = "/" | append: l | append: naked_path -%}
+        {%- endif -%}
       {%- endif -%}
       <link rel="alternate" hreflang="{{ l }}" {% static_href %}href="{{ site.url }}{{ alt_path }}"{% endstatic_href %}>
     {%- endfor -%}
-    <link rel="alternate" hreflang="x-default" {% static_href %}href="{{ site.url }}{{ canonical_path }}"{% endstatic_href %}>
+    <link rel="alternate" hreflang="x-default" {% static_href %}href="{{ site.url }}{{ naked_path }}"{% endstatic_href %}>
 
       <!-- Google Analytics -->
     {% if jekyll.environment == 'production' and site.google_analytics != empty %}
@@ -73,7 +89,7 @@
 <body>
     <header class="site-header">
         <div class="wrapper">
-            <a class="site-title" href="{% if lang == site.default_lang %}{{ '/' | relative_url }}{% else %}{{ '/' | append: lang | append: '/' | relative_url }}{% endif %}">{{ site.title }}</a>
+            <a class="site-title" href="{% if lang == site.default_lang %}{{ '/' | relative_url }}{% else %}{{ '/' | append: lang | append: '/' | relative_url }}{% endif %}">{{ localized_site_title }}</a>
             <nav class="site-nav">
                 <button class="menu-icon" aria-label="{{ t.nav.menu_toggle_aria }}">
                     <span></span>
@@ -102,9 +118,14 @@
                     <div class="lang-switcher-menu" role="menu">
                         {% for l in site.languages %}
                           {%- if l == site.default_lang -%}
-                            {%- assign target_url = canonical_path -%}
+                            {%- assign target_url = naked_path -%}
                           {%- else -%}
-                            {%- assign target_url = "/" | append: l | append: canonical_path -%}
+                            {%- assign sw_target_suffix = "." | append: l | append: ".html" -%}
+                            {%- if naked_path contains ".html" -%}
+                              {%- assign target_url = "/" | append: l | append: naked_path | replace_first: ".html", sw_target_suffix -%}
+                            {%- else -%}
+                              {%- assign target_url = "/" | append: l | append: naked_path -%}
+                            {%- endif -%}
                           {%- endif -%}
                           <a {% static_href %}href="{{ target_url }}"{% endstatic_href %} role="menuitem" data-lang="{{ l }}" {% if l == lang %}class="current"{% endif %}>
                             {% if l == 'en' %}English{% elsif l == 'zh' %}中文{% elsif l == 'ja' %}日本語{% endif %}
@@ -127,7 +148,7 @@
     </main>
     <footer class="site-footer">
         <div class="wrapper">
-            <p>&copy; {{ site.time | date: '%Y' }} {{ site.title }}. {{ t.footer.built_with }}</p>
+            <p>&copy; {{ site.time | date: '%Y' }} {{ localized_site_title }}. {{ t.footer.built_with }}</p>
         </div>
     </footer>
 

--- a/arcade.ja.md
+++ b/arcade.ja.md
@@ -3,6 +3,7 @@ layout: default
 title: arcade
 permalink: /arcade/
 lang: ja
+description: ブラウザで動くアーケードエミュレータ。ローカルゲームファイルをご自身で読み込む方式で、すべてブラウザの WASM サンドボックス内で実行。サーバーへのアップロードはありません。個人的な娯楽、合法な用途に限ります。
 ---
 
 <div class="hero-section">

--- a/arcade.md
+++ b/arcade.md
@@ -3,6 +3,7 @@ layout: default
 title: arcade
 permalink: /arcade/
 lang: en
+description: A browser-based arcade emulator. Bring your own local game files; everything runs inside the browser's WASM sandbox — nothing is uploaded. For personal entertainment, lawful use only.
 ---
 
 <div class="hero-section">

--- a/arcade.zh.md
+++ b/arcade.zh.md
@@ -3,6 +3,7 @@ layout: default
 title: arcade
 permalink: /arcade/
 lang: zh
+description: 一个跑在浏览器里的街机模拟器。本地文件自传，全程在浏览器的 WASM 沙箱里完成，零上传。仅供个人娱乐，合法用途。
 ---
 
 <div class="hero-section">

--- a/arcade/play/index.html
+++ b/arcade/play/index.html
@@ -5,7 +5,10 @@
     <link rel="icon" type="image/svg+xml" href="./joystick.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="referrer" content="no-referrer" />
-    <meta name="robots" content="index,follow" />
+    <!-- 这是个 React SPA 空壳（HTML 内容由 JS 运行时渲染），对搜索引擎
+         几乎没有可索引信息。索引它会被算成"低质量页面"，拖低站点权重。
+         入口介绍页在博客侧 /arcade/，那个才是给爬虫看的。 -->
+    <meta name="robots" content="noindex,follow" />
 
     <!--
       内容安全策略（CSP）：本应用与博客主站完全分离，独立 CSP。

--- a/index.ja.md
+++ b/index.ja.md
@@ -3,6 +3,7 @@ layout: default
 title: ホーム
 lang: ja
 permalink: /
+description: テクノロジー好き開発者の個人ブログ —— コーディングのメモ、使ったツール、いじり続けているプロジェクトを記録しています。
 ---
 
 <div class="hero-section">

--- a/index.md
+++ b/index.md
@@ -3,6 +3,7 @@ layout: default
 title: Home
 lang: en
 permalink: /
+description: A developer who loves technology — notes on coding, tools, and the projects I keep tinkering on.
 ---
 
 <div class="hero-section">

--- a/index.zh.md
+++ b/index.zh.md
@@ -3,6 +3,7 @@ layout: default
 title: 首页
 lang: zh
 permalink: /
+description: 一个热爱技术的开发者的个人博客 —— 记录写代码的心得、用过的工具、和我一直在折腾的项目。
 ---
 
 <div class="hero-section">

--- a/projects.ja.md
+++ b/projects.ja.md
@@ -3,6 +3,7 @@ layout: default
 title: プロジェクト
 permalink: /projects/
 lang: ja
+description: 個人プロジェクトとオープンソース貢献 —— aitm デスクトップターミナル、PDLC Claude Code プラグイン、ブラウザ用アーケードエミュレータ、そしてこのブログ本体。
 ---
 
 # プロジェクト

--- a/projects.md
+++ b/projects.md
@@ -3,6 +3,7 @@ layout: default
 title: Projects
 permalink: /projects/
 lang: en
+description: Personal projects and open-source contributions — aitm desktop terminal, PDLC Claude Code plugin, browser-based arcade emulator, and this blog itself.
 ---
 
 # Projects

--- a/projects.zh.md
+++ b/projects.zh.md
@@ -3,6 +3,7 @@ layout: default
 title: 项目展示
 permalink: /projects/
 lang: zh
+description: 个人项目与开源贡献清单 —— aitm 桌面终端、PDLC Claude Code 插件、浏览器街机模拟器，以及这个博客本身。
 ---
 
 # 项目展示

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,12 @@
+---
+permalink: /robots.txt
+layout: null
+---
+User-agent: *
+Allow: /
+
+# arcade 工具页是 SPA 空壳（实际内容由 JS 运行时渲染），HTML 几乎为空
+# 让搜索引擎跳过这里，避免被打成"低质量页面"拖低站点权重
+Disallow: /arcade/play/
+
+Sitemap: {{ site.url }}/sitemap.xml


### PR DESCRIPTION
## 起因

1. 用户反馈右上角 logo 在任何语言下都显示中文"功夫熊猫的博客"
2. SEO 审计发现：缺 sitemap / robots、arcade 工具页被索引、博客文章 hreflang 错位、EN/JA 首页 description 是中文等

## i18n 修复

- **右上角 logo 按语言切换**
  - EN: \`Kanfu Panda's Blog\`
  - ZH: \`功夫熊猫的博客\`
  - JA: \`カンフーパンダのブログ\`
- \`_data/i18n.yml\` 加 \`site_title\` 三语键
- \`_layouts/default.html\` 用 \`localized_site_title\` 替换 \`site.title\`（3 处）

## SEO P0（影响索引）

- ✅ 新增 \`robots.txt\`（手维护，允许全爬 + Disallow \`/arcade/play/\`）
- ✅ 加 \`jekyll-sitemap\` 插件，自动生成 \`/sitemap.xml\`（17 个 URL）
- ✅ arcade 工具页源端已加 \`<meta name="robots" content="noindex,follow">\`（依赖 [arcade_emulator PR #2](https://github.com/kanfu-panda/arcade_emulator/pull/2)；本 PR 含 sync 后的 \`arcade/play/index.html\`）

## SEO P1（多语言 SEO）

- **博客文章 hreflang 修复**：现在带正确的 \`.lang.html\` 后缀
  - 之前 EN 文章错误声明 ZH 版在 \`/zh/blog/.../pdlc-intro.html\`（polyglot fallback URL，实际是 EN 内容）
  - 修复后正确指向 \`/zh/blog/.../pdlc-intro.zh.html\`
- **三语 description 分别填写**：
  - \`index.{md,zh.md,ja.md}\`
  - \`arcade.{md,zh.md,ja.md}\`（之前 description 是博客默认描述）
  - \`projects.{md,zh.md,ja.md}\`
- **lang-switcher 链接同步修复**（同样的后缀处理逻辑）

## CLAUDE.md 新增两大约束章节

### 多语言（i18n）并行修改约束

- 内容文件清单（每组三语必齐）
- Frontmatter 必填字段（lang / title / description / excerpt / permalink）
- 共用资源清单（assets/ arcade/ 等不分语言的）
- 跨语言修改检查清单

### SEO 红线

- 必守约束（sitemap / robots / arcade noindex / canonical / hreflang / 三语 description / 单 h1 / CSP）
- 新增页面 SEO checklist
- 已知遗留 SEO 项（含优先级表）

## 自检

| 项 | 结果 |
|---|---|
| sitemap.xml | ✅ 17 URLs |
| robots.txt | ✅ 含 Disallow 与 Sitemap 指向 |
| 三语 logo | ✅ 各显示对应语言 |
| 三语 description | ✅ 各为对应语言 |
| arcade/play/ noindex | ✅ \`noindex,follow\` |
| ZH 文章 hreflang 三链 | ✅ 路径全部正确 |

## 已记为 P2 known issue

- \`jekyll-sitemap\` 不感知 polyglot，sitemap 缺多语言副本（靠 hreflang 引导爬虫发现）
- \`jekyll-seo-tag\` + polyglot 兼容性：非默认 lang 页 canonical 指 \`/\`（计划用 frontmatter \`canonical_url\` 显式覆盖）
- og:image 缺失（社交分享无缩略图）