### PR TITLE
feat(blog): 每篇文章底部加 kanfu-panda 署名

### DIFF
--- a/_data/i18n.yml
+++ b/_data/i18n.yml
@@ -22,6 +22,7 @@ en:
   post:
     published_on: Published on
     toc: Table of Contents
+    written_by: Written by
     lang_banner: "This post is written in {lang}. Switch to {alt_lang} version of the site or use your browser's translate feature."
     lang_label_zh: Chinese
     lang_label_en: English
@@ -53,6 +54,7 @@ zh:
   post:
     published_on: 发布于
     toc: 目录
+    written_by: 作者
     lang_banner: "本文为 {lang} 撰写。可切换到 {alt_lang} 站点，或使用浏览器自带的翻译功能。"
     lang_label_zh: 中文
     lang_label_en: 英文
@@ -84,6 +86,7 @@ ja:
   post:
     published_on: 公開日
     toc: 目次
+    written_by: 著者
     lang_banner: "この記事は{lang}で書かれています。{alt_lang}版サイトに切り替えるか、ブラウザの翻訳機能をご利用ください。"
     lang_label_zh: 中国語
     lang_label_en: 英語

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -88,6 +88,13 @@ layout: default
             {{ content }}
         </div>
     </div>
+
+    <footer class="post-author">
+        <a href="/" class="post-author-link">
+            <span class="post-author-label">{{ t.post.written_by }}</span>
+            <span class="post-author-name">kanfu-panda</span>
+        </a>
+    </footer>
 </article>
 
 <script>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -708,6 +708,36 @@ a:hover {
     }
 }
 
+/* 文章底部署名 */
+.post-author {
+    margin-top: 3rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border-color);
+
+    .post-author-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        text-decoration: none;
+        color: var(--text-color-secondary, #666);
+        font-size: 0.9rem;
+        transition: color 0.2s;
+
+        &:hover {
+            color: var(--main-color);
+        }
+    }
+
+    .post-author-label {
+        opacity: 0.7;
+    }
+
+    .post-author-name {
+        font-weight: 600;
+        color: var(--main-color);
+    }
+}
+
 /* Post Grid */
 .post-grid {
     display: grid;


### PR DESCRIPTION
每篇文章正文末尾加署名区块：「Written by / 作者 / 著者 **kanfu-panda**」，点击跳转博客首页。

改动：
- `_layouts/post.html`：正文后加 footer.post-author
- `_data/i18n.yml`：三语加 written_by 文案
- `assets/css/style.scss`：加署名样式（分隔线 + hover 变色）