### PR TITLE
fix(style): 给文章正文表格加边框/表头底/斑马纹

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -613,6 +613,34 @@ a:hover {
     strong {
         color: var(--main-color);
     }
+
+    /* 表格：minima 默认无边框，列糊在一起；这里补边框/表头底/内边距 */
+    table {
+        width: 100%;
+        margin: 1.5rem 0;
+        border-collapse: collapse;
+        font-size: 0.95rem;
+        /* 窄屏内容超宽时横向滚动，不撑破布局 */
+        display: block;
+        overflow-x: auto;
+    }
+
+    thead th {
+        background: var(--secondary-bg);
+        border-bottom: 2px solid var(--border-color);
+    }
+
+    th,
+    td {
+        padding: 0.5rem 0.85rem;
+        border: 1px solid var(--border-color);
+        text-align: left;
+        vertical-align: top;
+    }
+
+    tbody tr:nth-child(even) {
+        background: var(--secondary-bg);
+    }
 }
 
 /* Hero Section */


### PR DESCRIPTION
## 问题

minima 主题默认表格无任何边框/分隔线,文章正文里的三列表格(如 PDLC 第一篇的 層/数/役割)视觉上糊成一团、不像表格,**三种语言都一样**(共用 CSS)。

> 注:上一个 PR #30 合并时此 commit 还没推上去,漏进了 main,故单开本 PR 补上。

## 修复

在 `.post-text` 下补表格样式:
- `border-collapse` + 单元格 1px 边框
- 表头背景 + 2px 底边
- 偶数行斑马纹底色
- 窄屏 `overflow-x: auto` 横向滚动
- 沿用主题变量,明暗双模式自适应

## 验证

- SCSS 用 `sass` CLI 编译通过(退出码 0),规则正确生成且全部 scope 在 `.post-text` 下,不影响导航/卡片等其它表格。
- 本地 Ruby 环境 bundler 版本不匹配,无法跑整页 Jekyll 渲染。建议合并后在 GitHub Pages 上确认表格出现边框。