### PR TITLE
feat(comments): 用 Giscus 接入文章评论(替换 Gitalk)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,9 +20,19 @@ exclude_from_localization:
 # 并行构建加速
 parallel_localization: true
 
-# Gitalk 评论系统（暂时关闭：clientID/Secret 未配置会显示 Bad credentials）
-gitalk:
-  enable: false
+# Giscus 评论系统（基于 GitHub Discussions）
+# repo_id / category_id 是公开标识符，不是密钥，可安全入仓（区别于 Gitalk 的 clientSecret）。
+# 启用步骤见 docs/comments-giscus.md：在 giscus.app 生成 repo_id / category_id 填入即可。
+# repo_id 为空时评论框不渲染（安全默认，配好前不报错）。
+giscus:
+  enable: true
+  repo: "kanfu-panda/kanfu-panda.github.io"
+  repo_id: ""                 # 待填：从 giscus.app 复制
+  category: "Announcements"
+  category_id: ""             # 待填：从 giscus.app 复制
+  mapping: "pathname"         # 按 URL 建讨论串（三语各自独立）；改 "og:title" 可三语共享
+  reactions_enabled: "1"
+  input_position: "bottom"
 
 # Analytics settings
 google_analytics: "" # Will be set by GitHub Actions in production

--- a/_config.yml
+++ b/_config.yml
@@ -27,12 +27,13 @@ parallel_localization: true
 giscus:
   enable: true
   repo: "kanfu-panda/kanfu-panda.github.io"
-  repo_id: ""                 # 待填：从 giscus.app 复制
+  repo_id: "R_kgDOOzsMhw"           # 公开标识符，非密钥
   category: "Announcements"
-  category_id: ""             # 待填：从 giscus.app 复制
+  category_id: "DIC_kwDOOzsMh84C-y_s"  # 公开标识符，非密钥
   mapping: "pathname"         # 按 URL 建讨论串（三语各自独立）；改 "og:title" 可三语共享
   reactions_enabled: "1"
   input_position: "bottom"
+  loading: "lazy"             # 懒加载：滚动到评论区附近才加载 iframe
 
 # Analytics settings
 google_analytics: "" # Will be set by GitHub Actions in production

--- a/_data/i18n.yml
+++ b/_data/i18n.yml
@@ -24,6 +24,7 @@ en:
     published_on: Published on
     toc: Table of Contents
     written_by: Written by
+    comments: Comments
     lang_banner: "This post is written in {lang}. Switch to {alt_lang} version of the site or use your browser's translate feature."
     lang_label_zh: Chinese
     lang_label_en: English
@@ -57,6 +58,7 @@ zh:
     published_on: 发布于
     toc: 目录
     written_by: 作者
+    comments: 评论
     lang_banner: "本文为 {lang} 撰写。可切换到 {alt_lang} 站点，或使用浏览器自带的翻译功能。"
     lang_label_zh: 中文
     lang_label_en: 英文
@@ -90,6 +92,7 @@ ja:
     published_on: 公開日
     toc: 目次
     written_by: 著者
+    comments: コメント
     lang_banner: "この記事は{lang}で書かれています。{alt_lang}版サイトに切り替えるか、ブラウザの翻訳機能をご利用ください。"
     lang_label_zh: 中国語
     lang_label_en: 英語

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; font-src 'self' data: https://cdnjs.cloudflare.com; img-src 'self' data: https://www.google-analytics.com https://*.githubusercontent.com https://*.gravatar.com; connect-src 'self' https://api.github.com https://www.google-analytics.com https://*.analytics.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://github.com">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://www.googletagmanager.com https://www.google-analytics.com https://giscus.app; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; font-src 'self' data: https://cdnjs.cloudflare.com; img-src 'self' data: https://www.google-analytics.com https://*.githubusercontent.com https://*.gravatar.com; connect-src 'self' https://api.github.com https://www.google-analytics.com https://*.analytics.google.com; frame-src https://giscus.app; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://github.com">
     <meta name="referrer" content="strict-origin-when-cross-origin">
 
     <title>{% if page.title %}{{ page.title }} - {% endif %}{{ localized_site_title }}</title>
@@ -23,17 +23,6 @@
     <!-- og:image（社交分享缩略图） -->
     <meta property="og:image" content="{{ site.url }}/assets/images/og-image.png">
     <meta name="twitter:image" content="{{ site.url }}/assets/images/og-image.png">
-
-    {% if site.gitalk.enable and site.gitalk.clientID != empty and site.gitalk.clientSecret != empty and page.layout == 'post' and jekyll.environment == 'production' %}
-    <!-- Gitalk (锁版本 + SRI；升级时需重新生成 integrity，方法见 SECURITY.md) -->
-    <link rel="stylesheet"
-          href="https://cdn.jsdelivr.net/npm/gitalk@1.8.0/dist/gitalk.css"
-          integrity="sha384-X7z7PUv2B67D8sPJyzDyGZSco1ADwmdI7ed4eCGtTKkClfyDFpPL9WgAn9XVr/Io"
-          crossorigin="anonymous">
-    <script src="https://cdn.jsdelivr.net/npm/gitalk@1.8.0/dist/gitalk.min.js"
-            integrity="sha384-kspnZUWBoSWwoJHa0hBCXYbHGbhvU/lcEH5O8eVbSDhbPwsiVUTp/aGX/z/5EuMA"
-            crossorigin="anonymous"></script>
-    {% endif %}
 
     <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
     <link rel="stylesheet"
@@ -163,24 +152,6 @@
         </div>
     </footer>
 
-    {% if site.gitalk.enable and site.gitalk.clientID != empty and site.gitalk.clientSecret != empty and page.layout == 'post' and jekyll.environment == 'production' %}
-    <div id="gitalk-container"></div>
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        var gitalk = new Gitalk({
-          clientID: '{{ site.gitalk.clientID }}',
-          clientSecret: '{{ site.gitalk.clientSecret }}',
-          repo: '{{ site.gitalk.repo }}',
-          owner: '{{ site.gitalk.owner }}',
-          admin: ['{{ site.gitalk.owner }}'],
-          id: location.pathname.substr(0, 50),
-          language: '{{ lang }}' === 'zh' ? 'zh-CN' : ('{{ lang }}' === 'ja' ? 'ja' : 'en')
-        });
-        gitalk.render('gitalk-container');
-      });
-    </script>
-    {% endif %}
-
     <script>
         // === 菜单切换 ===
         document.querySelector('.menu-icon').addEventListener('click', function() {
@@ -200,10 +171,22 @@
             document.documentElement.setAttribute('data-theme', newTheme);
             localStorage.setItem('theme', newTheme);
             updateThemeIcon(newTheme);
+            syncGiscusTheme(newTheme);
         });
 
         function updateThemeIcon(theme) {
             icon.className = theme === 'dark' ? 'fas fa-sun' : 'fas fa-moon';
+        }
+
+        // === Giscus 评论框主题联动 ===
+        // 主题切换时通过 postMessage 通知 giscus iframe 同步明暗（iframe 不存在则静默跳过）
+        function syncGiscusTheme(theme) {
+            const frame = document.querySelector('iframe.giscus-frame');
+            if (!frame) return;
+            frame.contentWindow.postMessage(
+                { giscus: { setConfig: { theme: theme === 'dark' ? 'dark' : 'light' } } },
+                'https://giscus.app'
+            );
         }
 
         // === 语言切换器：toggle 菜单 ===

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -97,6 +97,38 @@ layout: default
     </footer>
 </article>
 
+{%- comment -%} Giscus 评论（基于 GitHub Discussions）。repo_id 配好前不渲染。 {%- endcomment -%}
+{% if site.giscus.enable and site.giscus.repo_id != empty %}
+<section class="post-comments" aria-label="{{ t.post.comments | default: 'Comments' }}">
+    <h2 class="post-comments-title">{{ t.post.comments | default: 'Comments' }}</h2>
+    <div id="giscus-comments"></div>
+</section>
+<script>
+(function () {
+    // 用 JS 动态插入 giscus，以便读取当前明暗主题作为初始 data-theme（主题存在 localStorage，纯客户端）
+    var theme = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+    var uiLang = {{ ui_lang | jsonify }};
+    var giscusLang = uiLang === 'zh' ? 'zh-CN' : (uiLang === 'ja' ? 'ja' : 'en');
+    var s = document.createElement('script');
+    s.src = 'https://giscus.app/client.js';
+    s.setAttribute('data-repo', {{ site.giscus.repo | jsonify }});
+    s.setAttribute('data-repo-id', {{ site.giscus.repo_id | jsonify }});
+    s.setAttribute('data-category', {{ site.giscus.category | jsonify }});
+    s.setAttribute('data-category-id', {{ site.giscus.category_id | jsonify }});
+    s.setAttribute('data-mapping', {{ site.giscus.mapping | default: 'pathname' | jsonify }});
+    s.setAttribute('data-strict', '0');
+    s.setAttribute('data-reactions-enabled', {{ site.giscus.reactions_enabled | default: '1' | jsonify }});
+    s.setAttribute('data-emit-metadata', '0');
+    s.setAttribute('data-input-position', {{ site.giscus.input_position | default: 'bottom' | jsonify }});
+    s.setAttribute('data-theme', theme);
+    s.setAttribute('data-lang', giscusLang);
+    s.setAttribute('crossorigin', 'anonymous');
+    s.async = true;
+    document.getElementById('giscus-comments').appendChild(s);
+})();
+</script>
+{% endif %}
+
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     // 生成目录

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -120,6 +120,7 @@ layout: default
     s.setAttribute('data-reactions-enabled', {{ site.giscus.reactions_enabled | default: '1' | jsonify }});
     s.setAttribute('data-emit-metadata', '0');
     s.setAttribute('data-input-position', {{ site.giscus.input_position | default: 'bottom' | jsonify }});
+    s.setAttribute('data-loading', {{ site.giscus.loading | default: 'lazy' | jsonify }});
     s.setAttribute('data-theme', theme);
     s.setAttribute('data-lang', giscusLang);
     s.setAttribute('crossorigin', 'anonymous');

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -615,6 +615,18 @@ a:hover {
     }
 }
 
+/* 文章评论区（Giscus） */
+.post-comments {
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--border-color);
+}
+
+.post-comments-title {
+    font-size: 1.3rem;
+    margin-bottom: 1.5rem;
+}
+
 /* Hero Section */
 .hero-section {
     background: var(--secondary-bg);

--- a/docs/comments-giscus.md
+++ b/docs/comments-giscus.md
@@ -1,0 +1,60 @@
+# 评论系统：Giscus 接入与启用
+
+博客评论基于 [Giscus](https://giscus.app)——把 GitHub Discussions 当评论后端。
+代码已接好（`_layouts/post.html` 渲染评论框、`_layouts/default.html` 做主题/CSP、
+`_config.yml` 存配置）。**只差 4 个公开标识符**，按下面三步填进 `_config.yml` 即可启用。
+
+> 为什么不用 Gitalk：Gitalk 需要 OAuth App 的 `clientSecret`，会被写进客户端 JS / 仓库，
+> 违反"秘钥不进仓库"原则。Giscus 的 `repo_id` / `category_id` 是**公开标识符不是密钥**，可安全入仓。
+
+## 启用步骤（一次性，约 5 分钟）
+
+### 1. 仓库开启 Discussions
+`github.com/kanfu-panda/kanfu-panda.github.io` → **Settings** → **General** →
+往下找 **Features** → 勾选 **Discussions**。
+
+进入新出现的 **Discussions** 标签 → 建一个分类（Category）专门放评论，
+建议名为 `Announcements`、类型选 **Announcement**（只有维护者能开新串，访客只能在已有串里回复——
+适合"一篇文章一条串"的评论场景）。
+
+### 2. 安装 giscus App
+打开 <https://github.com/apps/giscus> → **Install** → 选择本仓库授权。
+
+### 3. 生成 4 个值
+打开 <https://giscus.app>，在页面表单里：
+- **Repository** 填 `kanfu-panda/kanfu-panda.github.io`（绿勾表示三项前提都满足）
+- **Mapping** 选 `pathname`（默认；含义见下方"三语评论"）
+- **Discussion Category** 选第 1 步建的 `Announcements`
+
+往下滚动到 **Enable giscus** 区域，生成的 `<script>` 里有 4 个值，复制到 `_config.yml`：
+
+```yaml
+giscus:
+  enable: true
+  repo: "kanfu-panda/kanfu-panda.github.io"
+  repo_id: "R_xxxxxxxx"            # ← data-repo-id
+  category: "Announcements"
+  category_id: "DIC_xxxxxxxx"      # ← data-category-id
+  mapping: "pathname"
+  reactions_enabled: "1"
+  input_position: "bottom"
+```
+
+填好提交即生效（`repo_id` 为空时评论框不渲染，所以配好前不会报错或露半成品）。
+
+## 三语评论：独立还是共享
+
+`mapping: "pathname"`（当前默认）→ 按 URL 建讨论串。同一篇文章的中/英/日 URL 不同，
+所以**三语评论各自独立**（日文读者在日文串里聊）。多数三语博客这样最自然。
+
+若想**三语共享一条评论串**：把 `mapping` 改成 `"og:title"` 或 `"specific"`，
+但需保证三语版本有相同的映射键，较麻烦，一般不必。
+
+## 维护说明
+
+- 删评论 / 封人：去仓库 Discussions 对应讨论串操作（你是 admin）。
+- 主题联动：访客切换博客明暗主题时，评论框通过 `postMessage` 同步明暗
+  （逻辑在 `default.html` 的 `syncGiscusTheme`）。
+- 语言：评论框 UI 语言跟随文章语言（`post.html` 里按 `ui_lang` 映射 en/zh-CN/ja）。
+- CSP：`default.html` 的 CSP 已放行 `https://giscus.app`（`script-src` + `frame-src`）。
+  升级 giscus 或换域名时记得同步改。


### PR DESCRIPTION
## 背景

博客原有半成品 Gitalk(基于 GitHub Issues)需要 OAuth App 的 `clientSecret`,会被写进客户端 JS/仓库——违反秘钥不进仓库。本 PR 改用 **Giscus**(基于 GitHub Discussions):`repo_id`/`category_id` 是公开标识符不是密钥,可安全入仓。

## 改动

- **post.html**:文章末尾渲染评论框;按 `ui_lang` 映射 UI 语言(en/zh-CN/ja);用 JS 动态插入以读取当前明暗主题作为初始 `data-theme`
- **default.html**:CSP 放行 `giscus.app`(`script-src` + 新增 `frame-src`);主题切换时 `postMessage` 同步评论框明暗;移除原 Gitalk 加载/渲染块
- **_config.yml**:`giscus` 配置块,`repo_id` 留空时评论框**不渲染**(配好前安全,不露半成品)
- **i18n.yml**:三语补 `comments` 文案(Comments/评论/コメント)
- **style.scss**:评论区上分隔线样式
- **docs/comments-giscus.md**:启用步骤文档

## 三语评论

默认 `mapping: pathname` → 中/英/日各自独立讨论串(最自然)。改 `og:title` 可三语共享,文档里有说明。

## ⚠️ 合并后还需手动一步(无法代劳)

代码已就绪但**评论框默认不显示**,需你在 GitHub 上:
1. 仓库 Settings 开启 **Discussions** + 建 `Announcements` 分类
2. 安装 [giscus App](https://github.com/apps/giscus)
3. 去 <https://giscus.app> 生成 `repo_id` / `category_id` 填进 `_config.yml`

详见 `docs/comments-giscus.md`。

## 验证

用 rbenv Ruby 3.2.11 实跑 `bundle exec jekyll build`(退出码 0):
- 空 `repo_id`:三语 post 均**不含** `giscus.app/client.js`、无 `post-comments` 区块、无 Gitalk 残留 ✅
- 填测试 `repo_id`:三语均渲染评论块,`data-lang` 正确(en/zh-CN/ja),`repo_id`/`category_id` 正确注入,标题三语本地化,主题读取存在,CSP 含 `giscus.app` ✅
- SCSS `sass` 编译通过

> 注:真实评论交互(发评论/主题联动 postMessage)需配好 4 个值后在线上验证,本地无法模拟 GitHub 授权。