### PR TITLE
fix(comments): giscus 评论框撑满容器宽度

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -655,6 +655,12 @@ a:hover {
     margin-bottom: 1.5rem;
 }
 
+/* giscus iframe 默认是 HTML <iframe> 的 300px 固定宽，需显式撑满容器 */
+.post-comments .giscus,
+.post-comments .giscus-frame {
+    width: 100%;
+}
+
 /* Hero Section */
 .hero-section {
     background: var(--secondary-bg);


### PR DESCRIPTION
## 问题

评论框上线后宽度很窄(约 300px,见截图)。原因:giscus 的 `iframe.giscus-frame` 默认采用 HTML `<iframe>` 的 300px 固定宽,giscus **要求嵌入页面自己加** `.giscus / .giscus-frame { width: 100% }`(giscus.app 页面也提示用这俩选择器自定义容器布局)。上个 PR #32 接入时漏了这条。

## 修复

在 `.post-comments` 下补:
```scss
.post-comments .giscus,
.post-comments .giscus-frame { width: 100%; }
```

## 验证

rbenv ruby 3.2.11 `bundle exec jekyll build` 退出码 0,编译产物 `style.css` 含该规则。真实 iframe 撑满效果需线上 giscus 加载后确认。