### PR TITLE
fix(comments): 修复 giscus 暗色主题竞态 + 脚注加最后更新时间

### DIFF
--- a/_data/i18n.yml
+++ b/_data/i18n.yml
@@ -16,6 +16,7 @@ en:
     lang_switcher_aria: Switch language
   footer:
     built_with: Built with Jekyll.
+    last_updated: Last updated
   search:
     heading: Search Posts
     placeholder: Type keywords...
@@ -50,6 +51,7 @@ zh:
     lang_switcher_aria: 切换语言
   footer:
     built_with: Built with Jekyll.
+    last_updated: 最后更新
   search:
     heading: 搜索文章
     placeholder: 输入关键词搜索…
@@ -84,6 +86,7 @@ ja:
     lang_switcher_aria: 言語切替
   footer:
     built_with: Built with Jekyll.
+    last_updated: 最終更新
   search:
     heading: 記事を検索
     placeholder: キーワードを入力…

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -149,6 +149,7 @@
     <footer class="site-footer">
         <div class="wrapper">
             <p>&copy; {{ site.time | date: '%Y' }} {{ localized_site_title }}. {{ t.footer.built_with }}</p>
+            <p class="site-footer-updated">{{ t.footer.last_updated | default: 'Last updated' }}: {{ site.time | date: '%Y-%m-%d' }}</p>
         </div>
     </footer>
 
@@ -188,6 +189,14 @@
                 'https://giscus.app'
             );
         }
+
+        // giscus 加载完成（收到 discussion 就绪消息）后，主动推送当前页面主题，
+        // 消除初始主题竞态导致评论框明暗与页面不一致的问题
+        window.addEventListener('message', function (e) {
+            if (e.origin !== 'https://giscus.app') return;
+            if (!(e.data && e.data.giscus && e.data.giscus.discussion)) return;
+            syncGiscusTheme(document.documentElement.getAttribute('data-theme') || 'light');
+        });
 
         // === 语言切换器：toggle 菜单 ===
         (function () {

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -105,8 +105,11 @@ layout: default
 </section>
 <script>
 (function () {
-    // 用 JS 动态插入 giscus，以便读取当前明暗主题作为初始 data-theme（主题存在 localStorage，纯客户端）
-    var theme = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+    // 用 JS 动态插入 giscus。初始主题直接读 localStorage：此脚本在 body 中段执行，
+    // 早于页脚设置 data-theme 的脚本，读 DOM 属性会得到 null（默认 light），故直接读存储的真实值。
+    // 加载完成后页脚的 message 监听还会再推送一次主题，双保险。
+    var pageTheme = (function () { try { return localStorage.getItem('theme'); } catch (e) { return null; } })() || 'light';
+    var theme = pageTheme === 'dark' ? 'dark' : 'light';
     var uiLang = {{ ui_lang | jsonify }};
     var giscusLang = uiLang === 'zh' ? 'zh-CN' : (uiLang === 'ja' ? 'ja' : 'en');
     var s = document.createElement('script');

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -381,6 +381,15 @@ a:hover {
     padding: 2rem 0;
     color: #6a737d;
     text-align: center;
+
+    p {
+        margin: 0.3rem 0;
+    }
+}
+
+.site-footer-updated {
+    font-size: 0.85rem;
+    opacity: 0.75;
 }
 
 /* Search */


### PR DESCRIPTION
两处改动:

## 1. 评论框暗色 / 主题不一致(黑框)

亮色页面下评论框顶部渲染成黑色(giscus dark 主题 canvas `#0d1117`)。根因是**时序竞态**:giscus 嵌入脚本在 body 中段执行,读 `document.documentElement.getAttribute('data-theme')` 时,页脚设置主题的脚本还没运行(读到 null),且主题只在点击切换时才 postMessage 同步。

修复(giscus 官方推荐模式,双保险):
- 初始主题直接读 `localStorage.getItem('theme')`(真实值,不依赖尚未设置的 DOM 属性)
- 新增 `message` 监听:收到 giscus discussion 就绪消息后,主动 postMessage 推送当前页面主题 → 无论初始如何,加载完成必定与页面一致

## 2. 脚注加网站最后更新时间

页脚增加一行"最后更新: YYYY-MM-DD"(用 `site.time`,GitHub Pages 每次部署重新构建时刷新),三语 i18n(最后更新/最終更新/Last updated)。

## 验证

rbenv ruby 3.2.11 `bundle exec jekyll build` 退出码 0:
- 三语脚注更新时间正确渲染(2026-06-09)
- giscus ready 监听 + localStorage 初始主题均进入产物
- giscus 宽度规则未因分支合并重复(计数=1)

> 主题联动的真实效果(暗色页评论框跟随变暗)需线上 giscus 加载后确认,本地无法模拟 GitHub 授权。