### PR TITLE
fix(comments): giscus 主题补推不依赖 discussion + 去掉脚注 Built with Jekyll

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -148,7 +148,7 @@
     </main>
     <footer class="site-footer">
         <div class="wrapper">
-            <p>&copy; {{ site.time | date: '%Y' }} {{ localized_site_title }}. {{ t.footer.built_with }}</p>
+            <p>&copy; {{ site.time | date: '%Y' }} {{ localized_site_title }}</p>
             <p class="site-footer-updated">{{ t.footer.last_updated | default: 'Last updated' }}: {{ site.time | date: '%Y-%m-%d' }}</p>
         </div>
     </footer>
@@ -190,11 +190,14 @@
             );
         }
 
-        // giscus 加载完成（收到 discussion 就绪消息）后，主动推送当前页面主题，
-        // 消除初始主题竞态导致评论框明暗与页面不一致的问题
+        // giscus iframe 一就绪（收到任意 giscus 消息即说明可接收 postMessage）就推送当前主题。
+        // 不能只在带 discussion 的消息上触发——0 评论的页面尚未创建 discussion，那样永不补推，
+        // 会留下初始主题竞态导致的明暗不一致（黑框）。只补推一次即可，后续切换由 toggle 处理。
+        var giscusThemeSynced = false;
         window.addEventListener('message', function (e) {
             if (e.origin !== 'https://giscus.app') return;
-            if (!(e.data && e.data.giscus && e.data.giscus.discussion)) return;
+            if (!(e.data && e.data.giscus) || giscusThemeSynced) return;
+            giscusThemeSynced = true;
             syncGiscusTheme(document.documentElement.getAttribute('data-theme') || 'light');
         });
 


### PR DESCRIPTION
两处改动:

## 1. 评论框黑框(主题不同步)真正修复

上个 PR 的 ready 监听器要求 giscus 消息里含 `discussion` 才补推主题。但**0 评论的页面还没创建 discussion**,所以监听器一直 return,加载完成后从不补推 → 初始主题竞态留下的黑框无法自愈。

改为:收到**任意** giscus 消息(说明 iframe 已就绪可接收 postMessage)即补推一次当前页面主题;后续手动切换仍由 toggle 处理。

> 已用无头 Chrome 验证线上 iframe src 确实是 `theme=light`、giscus light widget 本身也是亮色(加载 light.css)。所以黑框是初始竞态/缓存遗留,本修复让加载完成后必定与页面主题对齐。

## 2. 去掉脚注 "Built with Jekyll."

按要求移除,脚注只保留 `© 2026 功夫熊猫的博客` + 最后更新时间。`built_with` i18n key 暂留(未使用,无害)。

## 验证

清 `.jekyll-cache` 后 `bundle exec jekyll build` 退出码 0(此前一次失败是本地缓存目录损坏,与改动无关):
- 三语脚注均无 "Built with Jekyll",保留最后更新行
- 三语均含修复后的监听器(单次补推、不再要求 discussion)