### PR TITLE
fix(comments): 主题切换整体重建 giscus，根治黑框割裂

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -172,34 +172,14 @@
             document.documentElement.setAttribute('data-theme', newTheme);
             localStorage.setItem('theme', newTheme);
             updateThemeIcon(newTheme);
-            syncGiscusTheme(newTheme);
+            // 主题切换时整体重建评论组件（见 post.html 的 renderGiscus），
+            // 避免 giscus setConfig 半切换导致反应区不跟随、输入框跟随的明暗割裂
+            if (window.renderGiscus) window.renderGiscus(newTheme);
         });
 
         function updateThemeIcon(theme) {
             icon.className = theme === 'dark' ? 'fas fa-sun' : 'fas fa-moon';
         }
-
-        // === Giscus 评论框主题联动 ===
-        // 主题切换时通过 postMessage 通知 giscus iframe 同步明暗（iframe 不存在则静默跳过）
-        function syncGiscusTheme(theme) {
-            const frame = document.querySelector('iframe.giscus-frame');
-            if (!frame) return;
-            frame.contentWindow.postMessage(
-                { giscus: { setConfig: { theme: theme === 'dark' ? 'dark' : 'light' } } },
-                'https://giscus.app'
-            );
-        }
-
-        // giscus iframe 一就绪（收到任意 giscus 消息即说明可接收 postMessage）就推送当前主题。
-        // 不能只在带 discussion 的消息上触发——0 评论的页面尚未创建 discussion，那样永不补推，
-        // 会留下初始主题竞态导致的明暗不一致（黑框）。只补推一次即可，后续切换由 toggle 处理。
-        var giscusThemeSynced = false;
-        window.addEventListener('message', function (e) {
-            if (e.origin !== 'https://giscus.app') return;
-            if (!(e.data && e.data.giscus) || giscusThemeSynced) return;
-            giscusThemeSynced = true;
-            syncGiscusTheme(document.documentElement.getAttribute('data-theme') || 'light');
-        });
 
         // === 语言切换器：toggle 菜单 ===
         (function () {

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -105,30 +105,38 @@ layout: default
 </section>
 <script>
 (function () {
-    // 用 JS 动态插入 giscus。初始主题直接读 localStorage：此脚本在 body 中段执行，
-    // 早于页脚设置 data-theme 的脚本，读 DOM 属性会得到 null（默认 light），故直接读存储的真实值。
-    // 加载完成后页脚的 message 监听还会再推送一次主题，双保险。
-    var pageTheme = (function () { try { return localStorage.getItem('theme'); } catch (e) { return null; } })() || 'light';
-    var theme = pageTheme === 'dark' ? 'dark' : 'light';
     var uiLang = {{ ui_lang | jsonify }};
     var giscusLang = uiLang === 'zh' ? 'zh-CN' : (uiLang === 'ja' ? 'ja' : 'en');
-    var s = document.createElement('script');
-    s.src = 'https://giscus.app/client.js';
-    s.setAttribute('data-repo', {{ site.giscus.repo | jsonify }});
-    s.setAttribute('data-repo-id', {{ site.giscus.repo_id | jsonify }});
-    s.setAttribute('data-category', {{ site.giscus.category | jsonify }});
-    s.setAttribute('data-category-id', {{ site.giscus.category_id | jsonify }});
-    s.setAttribute('data-mapping', {{ site.giscus.mapping | default: 'pathname' | jsonify }});
-    s.setAttribute('data-strict', '0');
-    s.setAttribute('data-reactions-enabled', {{ site.giscus.reactions_enabled | default: '1' | jsonify }});
-    s.setAttribute('data-emit-metadata', '0');
-    s.setAttribute('data-input-position', {{ site.giscus.input_position | default: 'bottom' | jsonify }});
-    s.setAttribute('data-loading', {{ site.giscus.loading | default: 'lazy' | jsonify }});
-    s.setAttribute('data-theme', theme);
-    s.setAttribute('data-lang', giscusLang);
-    s.setAttribute('crossorigin', 'anonymous');
-    s.async = true;
-    document.getElementById('giscus-comments').appendChild(s);
+
+    // 整体（重新）渲染评论组件。giscus 的 client.js 在加载时即把主题写死进 iframe src，
+    // 之后 setConfig 切换会出现反应区不跟随、输入框跟随的"半切换"割裂。故主题变化时直接
+    // 清空容器、用当前主题重新注入，保证整组件始终是单一主题。暴露到 window 供页脚主题切换调用。
+    window.renderGiscus = function (theme) {
+        var container = document.getElementById('giscus-comments');
+        if (!container) return;
+        container.innerHTML = '';
+        var s = document.createElement('script');
+        s.src = 'https://giscus.app/client.js';
+        s.setAttribute('data-repo', {{ site.giscus.repo | jsonify }});
+        s.setAttribute('data-repo-id', {{ site.giscus.repo_id | jsonify }});
+        s.setAttribute('data-category', {{ site.giscus.category | jsonify }});
+        s.setAttribute('data-category-id', {{ site.giscus.category_id | jsonify }});
+        s.setAttribute('data-mapping', {{ site.giscus.mapping | default: 'pathname' | jsonify }});
+        s.setAttribute('data-strict', '0');
+        s.setAttribute('data-reactions-enabled', {{ site.giscus.reactions_enabled | default: '1' | jsonify }});
+        s.setAttribute('data-emit-metadata', '0');
+        s.setAttribute('data-input-position', {{ site.giscus.input_position | default: 'bottom' | jsonify }});
+        s.setAttribute('data-loading', {{ site.giscus.loading | default: 'lazy' | jsonify }});
+        s.setAttribute('data-theme', theme === 'dark' ? 'dark' : 'light');
+        s.setAttribute('data-lang', giscusLang);
+        s.setAttribute('crossorigin', 'anonymous');
+        s.async = true;
+        container.appendChild(s);
+    };
+
+    // 初始渲染：直接读 localStorage 的真实主题（此脚本早于页脚设 data-theme 的脚本执行）
+    var pageTheme = (function () { try { return localStorage.getItem('theme'); } catch (e) { return null; } })() || 'light';
+    window.renderGiscus(pageTheme);
 })();
 </script>
 {% endif %}


### PR DESCRIPTION
## 真正的根因(这次定位准了)

之前两次修复(初始读 localStorage、ready 监听 postMessage)都没根治。这次用无头 Chrome + 抓 light.css 实测,锁定根因:

1. `light.css` 零暗色值——giscus 真用 light 主题不可能是黑的;你看到的黑框其实是 giscus **dark 主题**在渲染。
2. 关键现象:**同一 iframe 上面反应区黑、下面输入框亮**——单一主题不可能这样,说明是"先加载 dark、再被 setConfig 切 light 但只切了一半"。
3. 机理:giscus `client.js` 在**页面加载时**就把主题写死进 iframe 的 src(`loading=lazy` 只推迟网络请求,不改 URL)。开了懒加载后,**若先切主题、再滚到评论区**,iframe 锁的是旧主题;我之前的 `setConfig` 补救只切了输入框、反应区不跟随 → 黑框割裂。

## 修复

把注入逻辑抽成 `renderGiscus(theme)`。主题切换时**清空容器、用当前主题重新注入一个干净的 giscus**,整组件始终单一主题。移除 `setConfig` / message 监听补丁。

## 验证(这次真测了切换)

本地 `jekyll build` + `python -m http.server` + 无头 Chrome:
- 初始加载:产出 1 个 giscus-frame,theme=light ✓
- **模拟切换**:加载后调用 `renderGiscus('dark')` → giscus-frame 数量仍=**1**(旧的被清、无重复)、iframe **theme=dark** 正确切换 ✓ —— 证明重建机制干净生效,不再有半切换割裂。
- 三语产物均含 renderGiscus 定义、切换调用重建、已移除 setConfig。

> 部署后请硬刷新一次清掉浏览器缓存的旧暗色 iframe。之后无论你先切主题还是后切,评论框都会整体跟随,不再有黑框。