### PR TITLE
fix(comments): 锁定 giscus color-scheme，根治系统深色下的黑框

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -668,6 +668,14 @@ a:hover {
 .post-comments .giscus,
 .post-comments .giscus-frame {
     width: 100%;
+    /* 锁定 color-scheme：giscus 的 light 主题没固定 color-scheme，系统深色模式下
+       反应区透明背景会跟随系统变黑（上暗下亮割裂）。这里按页面主题强制锁定，覆盖系统偏好。 */
+    color-scheme: light;
+}
+
+:root[data-theme="dark"] .post-comments .giscus,
+:root[data-theme="dark"] .post-comments .giscus-frame {
+    color-scheme: dark;
 }
 
 /* Hero Section */


### PR DESCRIPTION
## 真正的根因(终于定位准了)

前几次修复(localStorage 初始主题、ready 监听、整体重建)都没命中,因为方向错了。这次用 Chrome DevTools Protocol 实测对比,锁定根因:

**黑框与博客主题、登录态、主题切换全无关——只取决于用户操作系统的 `prefers-color-scheme`。**

- giscus 的 `light.css` **没有固定 `color-scheme`**。
- 用户系统是**深色模式**时,评论区反应区(`0 个表情`/`0 条评论`那块,透明背景)跟随系统渲染成黑色,而输入框有显式背景所以是亮的 → 就是"上暗下亮"的割裂黑框。

## CDP 实测证据链

同一页面,仅改 `prefers-color-scheme` 模拟值:
- `light` → 评论区全白,无黑框
- `dark` → **黑框复现**(与用户截图一模一样)
- `dark` + 注入 `color-scheme:light` → 黑框消失,全白

## 修复

给 `.giscus / .giscus-frame` 按页面主题强制锁定 `color-scheme`(亮色页 `light`、暗色页 `dark`),覆盖系统偏好。

## 验证

本地 `jekyll build` + 起服务 + CDP 模拟 `prefers-color-scheme:dark`:修复后 iframe 计算样式 `color-scheme=light`,评论区**全亮、黑框消失**(已截图确认)。

> 这次是对着复现 + 验证修的,不是猜。部署后硬刷新即可。