### PR TITLE
fix(comments): 去掉 giscus 外框 + 关反应区让评论框更紧凑

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,7 +31,7 @@ giscus:
   category: "Announcements"
   category_id: "DIC_kwDOOzsMh84C-y_s"  # 公开标识符，非密钥
   mapping: "pathname"         # 按 URL 建讨论串（三语各自独立）；改 "og:title" 可三语共享
-  reactions_enabled: "1"
+  reactions_enabled: "0"      # 关闭顶部反应区，评论框更紧凑（空白反应区占高度）
   input_position: "bottom"
   loading: "lazy"             # 懒加载：滚动到评论区附近才加载 iframe
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -668,6 +668,8 @@ a:hover {
 .post-comments .giscus,
 .post-comments .giscus-frame {
     width: 100%;
+    /* 去掉 iframe 默认边框（那圈外框，暗色下尤其难看） */
+    border: none;
     /* 锁定 color-scheme：giscus 的 light 主题没固定 color-scheme，系统深色模式下
        反应区透明背景会跟随系统变黑（上暗下亮割裂）。这里按页面主题强制锁定，覆盖系统偏好。 */
     color-scheme: light;


### PR DESCRIPTION
承接颜色修复(#38),处理剩下两个外观问题:

## 1. 外框难看

giscus 的 iframe 有默认边框,暗色模式下显示为一圈灰白外框,很突兀。
修复:`.post-comments .giscus-frame { border: none }`。

## 2. 评论框太高

高度主要被顶部"反应/表情"区占据——即使 0 个表情,giscus 仍为该区预留约 350px(`0 个表情` + 笑脸 + 大段空白)。该区在 iframe 内部,无法从外部压缩,只能整块关闭。
经与 Leo 确认,关闭反应区(`reactions_enabled: 0`)换取紧凑布局。代价:访客不能给文章加 👍 等表情,但评论功能不受影响。

## 验证

CDP 实测(模拟系统明/暗):
- iframe 计算样式 `border-style: none` —— 外框已去除 ✓
- iframe 高度由开反应区时的 500+px 降到 **150px** —— 大幅变矮 ✓

> 无头截图未画出 composer(giscus 跨域内容绘制时序问题),但 DOM 指标确证两项修复均生效;线上真实浏览器会正常渲染输入框。